### PR TITLE
docs: remove low-value README note to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,3 @@ bash tests/download_sample_ppt.sh
 - モデルや PPT ファイルは git 管理対象外（`.gitignore`）
 - SmartArt など python-pptx が直接扱えないオブジェクトは制約あり
 
-## Development Notes
-- Added E2E test workflow notes for local Ollama verification.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ bash tests/download_sample_ppt.sh
 ## 注意
 - モデルや PPT ファイルは git 管理対象外（`.gitignore`）
 - SmartArt など python-pptx が直接扱えないオブジェクトは制約あり
+
+## Development Notes
+- Added E2E test workflow notes for local Ollama verification.


### PR DESCRIPTION
## Summary
This PR removes a low-value English note that made the README less consistent and less readable.

## Changes
- Removed the `Development Notes` section
- Kept the README structure focused and consistent

## Validation
- Docs-only change
- No runtime or implementation impact
