### PR TITLE
feat: improve PPT translation fidelity (font/style/glossary/indentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ pip install -r requirements.txt
 python -m ppt_local_translator.cli \
   --input ./source/input.pptx \
   --output-dir ./dest \
-  --model translategemma:4b
+  --model translategemma:4b \
+  --glossary ./glossary.json
 ```
 
 実行後、`dest/<元ファイル名>_ja.pptx` を生成します。
@@ -48,6 +49,20 @@ ollama pull translategemma:4b
 ```bash
 ollama --version
 ollama list
+```
+
+
+## Glossary (Do-not-translate terms)
+`glossary.json` can accumulate terms that must remain in English.
+
+```json
+{
+  "do_not_translate": [
+    "Infrastructure",
+    "Private Beta",
+    "Public Beta"
+  ]
+}
 ```
 
 ## テスト

--- a/glossary.json
+++ b/glossary.json
@@ -1,0 +1,7 @@
+{
+  "do_not_translate": [
+    "Infrastructure",
+    "Private Beta",
+    "Public Beta"
+  ]
+}

--- a/ppt_local_translator/cli.py
+++ b/ppt_local_translator/cli.py
@@ -15,6 +15,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--output-dir", required=True, type=Path, help="destination folder")
     p.add_argument("--model", required=True, choices=MODELS)
     p.add_argument("--ollama-url", default="http://localhost:11434")
+    p.add_argument("--glossary", type=Path, default=Path("./glossary.json"), help="glossary json path")
     return p.parse_args()
 
 
@@ -28,6 +29,7 @@ def main() -> None:
             model=args.model,
             output_dir=args.output_dir,
             base_url=args.ollama_url,
+            glossary_path=args.glossary,
         ),
     )
     print(f"Translated file generated: {out}")

--- a/ppt_local_translator/ollama_client.py
+++ b/ppt_local_translator/ollama_client.py
@@ -1,23 +1,75 @@
 from __future__ import annotations
 
+import json
+import re
+from pathlib import Path
+
 import requests
 
 
+DEFAULT_GLOSSARY = ["Infrastructure", "Private Beta", "Public Beta"]
+
+
 class OllamaTranslator:
-    def __init__(self, model: str, base_url: str = "http://localhost:11434") -> None:
+    def __init__(
+        self,
+        model: str,
+        base_url: str = "http://localhost:11434",
+        glossary_path: Path | None = None,
+    ) -> None:
         self.model = model
         self.base_url = base_url.rstrip("/")
+        self.glossary_path = glossary_path
+        self.glossary = self._load_glossary(glossary_path)
 
-    def translate_en_to_ja(self, text: str) -> str:
-        if not text or not text.strip():
-            return text
-        prompt = (
-            "Translate the following English text into natural Japanese. "
-            "Keep technical terms and product names in English. "
-            "Avoid literal translation; prefer context-aware short phrasing. "
-            "Return ONLY translated text with original line breaks preserved when possible.\n\n"
+    def _load_glossary(self, glossary_path: Path | None) -> list[str]:
+        terms = list(DEFAULT_GLOSSARY)
+        if not glossary_path:
+            return terms
+        try:
+            data = json.loads(Path(glossary_path).read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("do_not_translate"), list):
+                for term in data["do_not_translate"]:
+                    if isinstance(term, str) and term.strip() and term not in terms:
+                        terms.append(term)
+        except Exception:
+            pass
+        return terms
+
+    def _build_prompt(self, text: str, *, short_bullet: bool = False) -> str:
+        glossary_block = "\n".join(f"- {t}" for t in self.glossary)
+        short_sentence_rule = (
+            "For very short bullet items or very short standalone lines, do not append Japanese period '。'."
+            if short_bullet
+            else ""
+        )
+        return (
+            "Translate the following English text into natural Japanese for technical slides. "
+            "Keep technical terms and product names in English, strictly preserving the glossary terms. "
+            "Avoid literal translation; prefer concise, context-aware phrasing Japanese users prefer. "
+            "Preserve leading indentation spaces/tabs and keep meaningful line breaks at semantic boundaries. "
+            f"{short_sentence_rule}\n\n"
+            "Do-not-translate glossary:\n"
+            f"{glossary_block}\n\n"
+            "Return ONLY translated text.\n\n"
             f"TEXT:\n{text}"
         )
+
+    def translate_en_to_ja(self, text: str, *, short_bullet: bool = False) -> str:
+        if not text:
+            return text
+
+        # Preserve leading/trailing whitespace exactly.
+        lead_match = re.match(r"^[\t ]+", text)
+        trail_match = re.search(r"[\t ]+$", text)
+        leading = lead_match.group(0) if lead_match else ""
+        trailing = trail_match.group(0) if trail_match else ""
+        core = text[len(leading) : len(text) - len(trailing) if trailing else len(text)]
+
+        if not core.strip():
+            return text
+
+        prompt = self._build_prompt(core, short_bullet=short_bullet)
         try:
             resp = requests.post(
                 f"{self.base_url}/api/generate",
@@ -31,6 +83,10 @@ class OllamaTranslator:
             )
             resp.raise_for_status()
             data = resp.json()
-            return data.get("response", "").strip() or text
+            translated = data.get("response", "")
+            if not translated:
+                return text
+            translated = translated.rstrip("\n")
+            return f"{leading}{translated}{trailing}"
         except Exception:
             return text

--- a/ppt_local_translator/translator.py
+++ b/ppt_local_translator/translator.py
@@ -16,6 +16,7 @@ class TranslateConfig:
     model: str
     output_dir: Path
     base_url: str = "http://localhost:11434"
+    glossary_path: Path | None = None
 
 
 def _iter_shapes_recursive(shapes) -> Iterable:
@@ -25,7 +26,7 @@ def _iter_shapes_recursive(shapes) -> Iterable:
             yield from _iter_shapes_recursive(shape.shapes)
 
 
-def _estimate_font_size_pt(shape, text: str, min_pt: int = 10, max_pt: int = 28) -> int:
+def _estimate_font_size_pt(shape, text: str, min_pt: int = 8, max_pt: int = 28) -> int:
     if not text.strip():
         return min_pt
     width_pt = max(1, shape.width.pt)
@@ -33,47 +34,65 @@ def _estimate_font_size_pt(shape, text: str, min_pt: int = 10, max_pt: int = 28)
     char_count = max(1, len(text.replace("\n", "")))
     line_count = max(1, text.count("\n") + 1)
 
-    est_by_width = width_pt / (0.55 * (char_count / line_count + 2))
-    est_by_height = height_pt / (1.4 * line_count)
+    est_by_width = width_pt / (0.58 * (char_count / line_count + 2))
+    est_by_height = height_pt / (1.5 * line_count)
     est = int(max(min_pt, min(max_pt, min(est_by_width, est_by_height))))
     return est
 
 
-def _redistribute_text_to_runs(paragraph, translated_text: str) -> None:
+def _translate_paragraph_with_style_awareness(paragraph, translator: OllamaTranslator) -> str:
+    runs = list(paragraph.runs)
+    original = "".join(run.text for run in runs) or paragraph.text
+    if not original.strip():
+        return original
+
+    # Full-context translation.
+    short_bullet = paragraph.level > 0 and len(original.strip()) <= 24
+    full_translated = translator.translate_en_to_ja(original, short_bullet=short_bullet)
+
+    # If styled runs are present, also do run-level translation to preserve style ranges.
+    has_multi_style = len(runs) > 1 and len({(r.font.bold, r.font.italic, r.font.underline, getattr(r.font.color, "rgb", None)) for r in runs}) > 1
+    if has_multi_style:
+        for run in runs:
+            run.text = translator.translate_en_to_ja(run.text, short_bullet=short_bullet)
+        return "".join(r.text for r in runs)
+
+    # No meaningful style boundaries: keep full-context result.
+    if runs:
+        runs[0].text = full_translated
+        for run in runs[1:]:
+            run.text = ""
+    else:
+        paragraph.text = full_translated
+    return full_translated
+
+
+def _apply_font_policy(paragraph, shape, translated_text: str) -> None:
     runs = list(paragraph.runs)
     if not runs:
-        paragraph.text = translated_text
         return
 
-    total = sum(max(1, len(r.text)) for r in runs)
-    idx = 0
-    remaining = translated_text
-    for i, run in enumerate(runs):
-        if i == len(runs) - 1:
-            run.text = remaining
-            break
-        weight = max(1, len(run.text)) / total
-        take = int(round(len(translated_text) * weight))
-        chunk = translated_text[idx : idx + take]
-        run.text = chunk
-        idx += len(chunk)
-        remaining = translated_text[idx:]
+    orig_sizes = []
+    for run in runs:
+        pt = run.font.size.pt if run.font.size else None
+        if pt is not None:
+            orig_sizes.append(float(pt))
+
+    max_orig = max(orig_sizes) if orig_sizes else 18.0
+    target_max = _estimate_font_size_pt(shape, translated_text, min_pt=8, max_pt=int(max(10, max_orig)))
+    scale = min(1.0, target_max / max_orig) if max_orig > 0 else 1.0
+
+    for run in runs:
+        run.font.name = "Meiryo"
+        base = run.font.size.pt if run.font.size else max_orig
+        run.font.size = Pt(max(8, round(base * scale, 1)))
 
 
 def _translate_text_frame(shape, translator: OllamaTranslator) -> None:
     tf = shape.text_frame
     for paragraph in tf.paragraphs:
-        original = "".join(run.text for run in paragraph.runs) or paragraph.text
-        if not original.strip():
-            continue
-
-        translated = translator.translate_en_to_ja(original)
-        _redistribute_text_to_runs(paragraph, translated)
-
-        size_pt = _estimate_font_size_pt(shape, translated)
-        for run in paragraph.runs:
-            run.font.name = "Meiryo"
-            run.font.size = Pt(size_pt)
+        translated_text = _translate_paragraph_with_style_awareness(paragraph, translator)
+        _apply_font_policy(paragraph, shape, translated_text)
 
 
 def _translate_table(shape, translator: OllamaTranslator) -> None:
@@ -81,19 +100,22 @@ def _translate_table(shape, translator: OllamaTranslator) -> None:
     for row in table.rows:
         for cell in row.cells:
             for paragraph in cell.text_frame.paragraphs:
-                original = "".join(run.text for run in paragraph.runs) or paragraph.text
-                if not original.strip():
-                    continue
-                translated = translator.translate_en_to_ja(original)
-                _redistribute_text_to_runs(paragraph, translated)
+                translated_text = _translate_paragraph_with_style_awareness(paragraph, translator)
                 for run in paragraph.runs:
                     run.font.name = "Meiryo"
-                    run.font.size = Pt(14)
+                    if run.font.size:
+                        run.font.size = Pt(max(8, run.font.size.pt))
+                if not paragraph.runs:
+                    paragraph.text = translated_text
 
 
 def translate_ppt(input_path: Path, config: TranslateConfig) -> Path:
     prs = Presentation(str(input_path))
-    translator = OllamaTranslator(model=config.model, base_url=config.base_url)
+    translator = OllamaTranslator(
+        model=config.model,
+        base_url=config.base_url,
+        glossary_path=config.glossary_path,
+    )
 
     for slide in prs.slides:
         for shape in _iter_shapes_recursive(slide.shapes):

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ppt_local_translator.ollama_client import OllamaTranslator
 
 
@@ -11,3 +13,22 @@ def test_ollama_fallback_on_error(monkeypatch):
     tr = OllamaTranslator("translategemma:4b")
     text = "Hello Cloud"
     assert tr.translate_en_to_ja(text) == text
+
+
+def test_preserve_leading_whitespace_on_fallback(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("down")
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", boom)
+    tr = OllamaTranslator("translategemma:4b")
+    text = "\t  Infrastructure"
+    assert tr.translate_en_to_ja(text) == text
+
+
+def test_load_glossary_file(tmp_path: Path):
+    g = tmp_path / "glossary.json"
+    g.write_text('{"do_not_translate":["Kubernetes"]}', encoding="utf-8")
+    tr = OllamaTranslator("translategemma:4b", glossary_path=g)
+    assert "Kubernetes" in tr.glossary

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -10,7 +10,7 @@ class DummyTranslator:
     def __init__(self, *args, **kwargs):
         pass
 
-    def translate_en_to_ja(self, text: str) -> str:
+    def translate_en_to_ja(self, text: str, *, short_bullet: bool = False) -> str:
         return f"JA:{text}"
 
 
@@ -70,4 +70,31 @@ def test_estimate_font_size_pt_range():
         height = D(120)
 
     size = t._estimate_font_size_pt(S(), "short text")
-    assert 10 <= size <= 28
+    assert 8 <= size <= 28
+
+
+def test_style_range_translation_when_multi_run(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(t, "OllamaTranslator", DummyTranslator)
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(7), Inches(2))
+    p = box.text_frame.paragraphs[0]
+    r1 = p.add_run()
+    r1.text = "Private Beta"
+    r1.font.bold = True
+    r2 = p.add_run()
+    r2.text = " starts now"
+    r2.font.bold = False
+
+    in_path = tmp_path / "style.pptx"
+    prs.save(in_path)
+
+    out = t.translate_ppt(in_path, t.TranslateConfig(model="translategemma:4b", output_dir=tmp_path))
+    out_prs = Presentation(out)
+    p2 = out_prs.slides[0].shapes[0].text_frame.paragraphs[0]
+
+    assert p2.runs[0].text.startswith("JA:")
+    assert p2.runs[1].text.startswith("JA:")
+    assert p2.runs[0].font.bold is True
+    assert p2.runs[1].font.bold is False


### PR DESCRIPTION
## Summary
This PR implements the quality feedback for translation fidelity and formatting preservation.

## Product decisions applied
- Preserve style ranges as close as possible for mixed-format sentences.
- Keep source-like font sizing with absolute-point scaling only when needed.
- Preserve indentation (leading tabs/spaces).
- Introduce an extensible glossary for do-not-translate technical terms.
- Avoid unnecessary Japanese period `。` for very short bullet lines.

## Changes
- Added glossary support (`glossary.json`, `--glossary` CLI option).
- Updated Ollama prompt rules for:
  - technical term preservation
  - semantic line-break guidance
  - short-bullet punctuation rule
- Implemented hybrid translation strategy:
  - full-context translation
  - run-level style-aware translation path for multi-style paragraphs
- Improved font handling:
  - source run sizes as baseline
  - absolute-point down-scaling heuristic to improve box fit
- Added/updated tests for style-range behavior, glossary loading, and whitespace preservation.

## Validation
- `pytest -q` => 9 passed
- `pytest -q -m e2e` (local) => passed previously with local Ollama

## Related issues
- Closes #2
- Closes #3
- Closes #4
- Closes #5
