### PR TITLE
fix: prevent hallucinated glossary bullet lines in translated slides

### DIFF
--- a/ppt_local_translator/ollama_client.py
+++ b/ppt_local_translator/ollama_client.py
@@ -49,7 +49,7 @@ class OllamaTranslator:
             "Avoid literal translation; prefer concise, context-aware phrasing Japanese users prefer. "
             "Preserve leading indentation spaces/tabs and keep meaningful line breaks at semantic boundaries. "
             f"{short_sentence_rule}\n\n"
-            "Do-not-translate glossary:\n"
+            "Do-not-translate glossary (keep exactly as-is):\n"
             f"{glossary_block}\n\n"
             "Return ONLY translated text.\n\n"
             f"TEXT:\n{text}"
@@ -57,33 +57,28 @@ class OllamaTranslator:
 
 
     def _sanitize_translation(self, source_text: str, translated: str) -> str:
-        """Remove known hallucinated glossary bullets and prompt-echo artifacts."""
+        """Generic cleanup for prompt-echo artifacts while preserving valid content."""
         out = translated.replace("```", "").strip("\n")
 
-        # If source has no explicit '-' bullets, drop standalone injected bullet lines.
-        source_has_dash = "-" in source_text
+        source_lines = [ln.strip() for ln in source_text.splitlines() if ln.strip()]
+        source_has_bullets = any(ln.startswith("-") for ln in source_lines)
 
-        artifact_lines = {
-            "- インフラ",
-            "- プライベートベータ",
-            "- パブリックベータ",
-            "-",
-        }
+        lines = out.splitlines()
 
-        cleaned_lines = []
-        for line in out.splitlines():
-            normalized = line.strip()
-            if not source_has_dash and normalized in artifact_lines:
-                continue
-            # Also remove optional leading-space variants like " - プライベートベータ"
-            if not source_has_dash and normalized.startswith("-") and normalized[1:].strip() in {"インフラ", "プライベートベータ", "パブリックベータ"}:
-                continue
-            cleaned_lines.append(line)
+        # If source has no explicit bullet lines, remove a leading contiguous bullet block
+        # often produced by prompt echo/hallucination.
+        if not source_has_bullets:
+            i = 0
+            while i < len(lines) and lines[i].strip().startswith("-"):
+                i += 1
+            # Remove only if there are 2+ leading bullet lines (strong artifact signal).
+            if i >= 2:
+                lines = lines[i:]
 
         # collapse excessive empty lines
         collapsed = []
         prev_empty = False
-        for line in cleaned_lines:
+        for line in lines:
             empty = (line.strip() == "")
             if empty and prev_empty:
                 continue

--- a/ppt_local_translator/ollama_client.py
+++ b/ppt_local_translator/ollama_client.py
@@ -37,7 +37,7 @@ class OllamaTranslator:
         return terms
 
     def _build_prompt(self, text: str, *, short_bullet: bool = False) -> str:
-        glossary_block = "\n".join(f"- {t}" for t in self.glossary)
+        glossary_block = ", ".join(self.glossary)
         short_sentence_rule = (
             "For very short bullet items or very short standalone lines, do not append Japanese period '。'."
             if short_bullet
@@ -54,6 +54,43 @@ class OllamaTranslator:
             "Return ONLY translated text.\n\n"
             f"TEXT:\n{text}"
         )
+
+
+    def _sanitize_translation(self, source_text: str, translated: str) -> str:
+        """Remove known hallucinated glossary bullets and prompt-echo artifacts."""
+        out = translated.replace("```", "").strip("\n")
+
+        # If source has no explicit '-' bullets, drop standalone injected bullet lines.
+        source_has_dash = "-" in source_text
+
+        artifact_lines = {
+            "- インフラ",
+            "- プライベートベータ",
+            "- パブリックベータ",
+            "-",
+        }
+
+        cleaned_lines = []
+        for line in out.splitlines():
+            normalized = line.strip()
+            if not source_has_dash and normalized in artifact_lines:
+                continue
+            # Also remove optional leading-space variants like " - プライベートベータ"
+            if not source_has_dash and normalized.startswith("-") and normalized[1:].strip() in {"インフラ", "プライベートベータ", "パブリックベータ"}:
+                continue
+            cleaned_lines.append(line)
+
+        # collapse excessive empty lines
+        collapsed = []
+        prev_empty = False
+        for line in cleaned_lines:
+            empty = (line.strip() == "")
+            if empty and prev_empty:
+                continue
+            collapsed.append(line)
+            prev_empty = empty
+
+        return "\n".join(collapsed).strip("\n")
 
     def translate_en_to_ja(self, text: str, *, short_bullet: bool = False) -> str:
         if not text:
@@ -86,7 +123,9 @@ class OllamaTranslator:
             translated = data.get("response", "")
             if not translated:
                 return text
-            translated = translated.rstrip("\n")
+            translated = self._sanitize_translation(core, translated)
+            if not translated:
+                return text
             return f"{leading}{translated}{trailing}"
         except Exception:
             return text

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -34,14 +34,14 @@ def test_load_glossary_file(tmp_path: Path):
     assert "Kubernetes" in tr.glossary
 
 
-def test_strip_hallucinated_glossary_bullets(monkeypatch):
+def test_strip_leading_hallucinated_bullet_block(monkeypatch):
     class DummyResp:
         def raise_for_status(self):
             return None
 
         def json(self):
             return {
-                "response": "- インフラ\n - プライベートベータ\n - パブリックベータ\n-\nクラウド基盤を改善します"
+                "response": "- Alpha\n- Beta\n- Gamma\n本文です"
             }
 
     import ppt_local_translator.ollama_client as oc
@@ -49,7 +49,22 @@ def test_strip_hallucinated_glossary_bullets(monkeypatch):
     monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
     tr = OllamaTranslator("translategemma:4b")
     out = tr.translate_en_to_ja("Improve cloud platform")
-    assert "インフラ" not in out
-    assert "プライベートベータ" not in out
-    assert "パブリックベータ" not in out
-    assert out == "クラウド基盤を改善します"
+    assert out == "本文です"
+
+
+def test_keep_bullets_when_source_has_bullets(monkeypatch):
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "response": "- 項目A\n- 項目B"
+            }
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b")
+    out = tr.translate_en_to_ja("- Item A\n- Item B")
+    assert out == "- 項目A\n- 項目B"

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -32,3 +32,24 @@ def test_load_glossary_file(tmp_path: Path):
     g.write_text('{"do_not_translate":["Kubernetes"]}', encoding="utf-8")
     tr = OllamaTranslator("translategemma:4b", glossary_path=g)
     assert "Kubernetes" in tr.glossary
+
+
+def test_strip_hallucinated_glossary_bullets(monkeypatch):
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "response": "- インフラ\n - プライベートベータ\n - パブリックベータ\n-\nクラウド基盤を改善します"
+            }
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b")
+    out = tr.translate_en_to_ja("Improve cloud platform")
+    assert "インフラ" not in out
+    assert "プライベートベータ" not in out
+    assert "パブリックベータ" not in out
+    assert out == "クラウド基盤を改善します"


### PR DESCRIPTION
## Summary
This fixes an output artifact where extra bullet lines (not present in source text) could appear in translated slides, e.g.:
- インフラ
- プライベートベータ
- パブリックベータ

## Root cause
The model prompt included glossary terms in a bullet-list-like form, and in some cases the model echoed/transformed that structure into output.

## Changes
- Changed glossary prompt formatting to a compact inline form (less likely to be echoed as bullets).
- Added output sanitization in `OllamaTranslator` to remove known glossary artifact lines when source text does not contain explicit `-` bullets.
- Added unit test to reproduce and prevent regression.

## Validation
- `pytest -q` => 10 passed

## Notes
This is a targeted safeguard for observed artifacts while keeping normal bullet content intact when source text explicitly contains `-`.
