### PR TITLE
fix: preserve URL schemes and link segments from translation

### DIFF
--- a/ppt_local_translator/ollama_client.py
+++ b/ppt_local_translator/ollama_client.py
@@ -28,6 +28,30 @@ class OllamaTranslator:
             f"TEXT:\n{text}"
         )
 
+
+    def _mask_urls(self, text: str):
+        # Preserve URLs/slack-style links from translation.
+        patterns = [
+            r"<https?://[^>]+>",
+            r"https?://[^\s)\]}>]+",
+        ]
+        combined = re.compile("|".join(f"({p})" for p in patterns))
+        tokens = []
+
+        def repl(m):
+            token = f"__URLTOKEN_{len(tokens)}__"
+            tokens.append(m.group(0))
+            return token
+
+        masked = combined.sub(repl, text)
+        return masked, tokens
+
+    def _unmask_urls(self, text: str, tokens):
+        out = text
+        for i, v in enumerate(tokens):
+            out = out.replace(f"__URLTOKEN_{i}__", v)
+        return out
+
     def _sanitize_translation(self, source_text: str, translated: str) -> str:
         out = translated.replace("```", "").replace("**", "").strip("\n")
 
@@ -60,12 +84,14 @@ class OllamaTranslator:
         if not core.strip():
             return text
 
+        masked_core, url_tokens = self._mask_urls(core)
+
         try:
             resp = requests.post(
                 f"{self.base_url}/api/generate",
                 json={
                     "model": self.model,
-                    "prompt": self._build_prompt(core, short_bullet=short_bullet),
+                    "prompt": self._build_prompt(masked_core, short_bullet=short_bullet),
                     "stream": False,
                     "options": {"temperature": 0.2},
                 },
@@ -77,6 +103,7 @@ class OllamaTranslator:
             if not translated:
                 return text
             translated = self._sanitize_translation(core, translated)
+            translated = self._unmask_urls(translated, url_tokens)
             return f"{leading}{translated}{trailing}" if translated else text
         except Exception:
             return text

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -44,3 +44,36 @@ def test_preserve_existing_line_count(monkeypatch):
     tr = OllamaTranslator("translategemma:4b")
     out = tr.translate_en_to_ja("Line1\nLine2")
     assert out.count("\n") == 1
+
+
+def test_preserve_http_url_tokens(monkeypatch):
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": "参照: __URLTOKEN_0__"}
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b")
+    out = tr.translate_en_to_ja("See https://example.com/docs?q=1")
+    assert "https://example.com/docs?q=1" in out
+
+
+def test_preserve_angle_bracket_url(monkeypatch):
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": "リンク: __URLTOKEN_0__"}
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b")
+    src = "Link <http://example.com/path|http:/> details"
+    out = tr.translate_en_to_ja(src)
+    assert "<http://example.com/path|http:/>" in out


### PR DESCRIPTION
## Summary
This PR prevents URL-like segments from being translated.

## Details
- Preserve plain URLs starting with `http://` or `https://`.
- Preserve angle-bracket links such as `<http://...>`.
- Preserve Slack-style link forms such as `<http://...|...>`.
- Implemented masking/unmasking around translation so URL segments remain byte-stable.

## Validation
- `pytest -q` => 13 passed
- Added tests for plain URL and angle-bracket URL preservation.
