### PR TITLE
feat: preserve glossary nouns with deterministic placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 *.pyc
 .venv/
 .pytest_cache/
+
+# local glossary (user-editable, do not commit)
+config/local_glossary

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ ollama list
 ```
 
 
+
+## 用語グローサリー（翻訳しない英語名詞）
+- `config/local_glossary` に **1行1用語** で登録すると、その語は翻訳前にプレースホルダへ置換し、翻訳後に英語へ復元します。
+- 復元できない（プレースホルダ欠落）場合はエラーとして検知し、誤変換のまま進めません。
+- 最長一致・単語境界でマッチするため、短い語の部分一致による誤検知を抑えます。
+
+初期テンプレート: `config/glossary.sample`
+
+```bash
+cp config/glossary.sample config/local_glossary
+# 必要な名詞を追記
+```
+
+`config/local_glossary` は `.gitignore` 済みで、ユーザーごとの差分をコミットしない運用です。
+
 ## テスト
 ```bash
 pytest -q

--- a/config/glossary.sample
+++ b/config/glossary.sample
@@ -1,0 +1,7 @@
+# One term per line. Nouns / proper nouns recommended.
+# These terms will be preserved in English by placeholder masking.
+Cloud Native
+Kubernetes
+Amazon EC2
+S3
+GitHub Actions

--- a/ppt_local_translator/ollama_client.py
+++ b/ppt_local_translator/ollama_client.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import requests
 
 
+_WORD_BOUNDARY = r"[A-Za-z0-9_]"
+_GLOSSARY_TOKEN_FMT = "⟪GLS_{:04d}⟫"
+
+
 class OllamaTranslator:
-    def __init__(self, model: str, base_url: str = "http://localhost:11434") -> None:
+    def __init__(
+        self,
+        model: str,
+        base_url: str = "http://localhost:11434",
+        glossary_path: Path | None = None,
+    ) -> None:
         self.model = model
         self.base_url = base_url.rstrip("/")
+        self.glossary_path = glossary_path or Path("config/local_glossary")
 
     def _build_prompt(self, text: str, *, short_bullet: bool = False) -> str:
         short_sentence_rule = (
@@ -28,9 +39,61 @@ class OllamaTranslator:
             f"TEXT:\n{text}"
         )
 
+    def _load_glossary_terms(self) -> list[str]:
+        path = self.glossary_path
+        if not path.exists():
+            return []
+        terms: list[str] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            terms.append(s)
+        # deterministic: dedupe while preserving order, then longest-first
+        seen: set[str] = set()
+        ordered = [t for t in terms if not (t in seen or seen.add(t))]
+        ordered.sort(key=lambda x: (-len(x), x))
+        return ordered
+
+    def _mask_glossary_terms(self, text: str):
+        terms = self._load_glossary_terms()
+        if not terms:
+            return text, []
+
+        masked = text
+        tokens: list[str] = []
+
+        for term in terms:
+            pattern = re.compile(
+                rf"(?<!{_WORD_BOUNDARY})({re.escape(term)})(?!{_WORD_BOUNDARY})"
+            )
+
+            def repl(_m):
+                token = _GLOSSARY_TOKEN_FMT.format(len(tokens))
+                tokens.append(term)
+                return token
+
+            masked = pattern.sub(repl, masked)
+
+        return masked, tokens
+
+    def _unmask_glossary_terms(self, text: str, tokens: list[str]) -> str:
+        out = text
+        missing: list[str] = []
+
+        for i, term in enumerate(tokens):
+            token = _GLOSSARY_TOKEN_FMT.format(i)
+            if token not in out:
+                missing.append(token)
+            out = out.replace(token, term)
+
+        if missing:
+            raise ValueError(
+                "Glossary placeholder missing after translation: " + ", ".join(missing)
+            )
+        return out
 
     def _mask_urls(self, text: str):
-        # Preserve URLs/slack-style links from translation.
         patterns = [
             r"<https?://[^>]+>",
             r"https?://[^\s)\]}>]+",
@@ -39,7 +102,6 @@ class OllamaTranslator:
         tokens = []
 
         def repl(m):
-            # Use a machine-ish token less likely to be naturally translated.
             token = f"<<<URLTOKEN_{len(tokens)}>>>"
             tokens.append(m.group(0))
             return token
@@ -50,10 +112,8 @@ class OllamaTranslator:
     def _unmask_urls(self, text: str, tokens):
         out = text
         for i, v in enumerate(tokens):
-            # Exact placeholder first.
             out = out.replace(f"<<<URLTOKEN_{i}>>>", v)
 
-            # Tolerate LLM-normalized variants (e.g. "URLトークン0", "URL token 0").
             tolerant = [
                 re.compile(rf"URL\s*TOKEN\s*_?\s*{i}", re.IGNORECASE),
                 re.compile(rf"URL\s*トークン\s*{i}"),
@@ -67,11 +127,9 @@ class OllamaTranslator:
     def _sanitize_translation(self, source_text: str, translated: str) -> str:
         out = translated.replace("```", "").replace("**", "").strip("\n")
 
-        # Do not insert new line breaks if source had none.
         if "\n" not in source_text:
             out = out.replace("\n", " ")
 
-        # If source has N lines, cap output lines to N by joining extras.
         src_lines = source_text.count("\n") + 1
         parts = out.splitlines()
         if len(parts) > src_lines:
@@ -79,7 +137,6 @@ class OllamaTranslator:
             tail = " ".join(p.strip() for p in parts[src_lines - 1 :] if p.strip())
             out = "\n".join(head + [tail]) if head else tail
 
-        # collapse excessive spaces
         out = re.sub(r"[ \t]{2,}", " ", out)
         return out.strip("\n")
 
@@ -97,6 +154,7 @@ class OllamaTranslator:
             return text
 
         masked_core, url_tokens = self._mask_urls(core)
+        masked_core, glossary_tokens = self._mask_glossary_terms(masked_core)
 
         try:
             resp = requests.post(
@@ -116,6 +174,9 @@ class OllamaTranslator:
                 return text
             translated = self._sanitize_translation(core, translated)
             translated = self._unmask_urls(translated, url_tokens)
+            translated = self._unmask_glossary_terms(translated, glossary_tokens)
             return f"{leading}{translated}{trailing}" if translated else text
+        except ValueError:
+            raise
         except Exception:
             return text

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -77,3 +77,69 @@ def test_preserve_angle_bracket_url(monkeypatch):
     src = "Link <http://example.com/path|http:/> details"
     out = tr.translate_en_to_ja(src)
     assert "<http://example.com/path|http:/>" in out
+
+
+def test_glossary_longest_match_and_boundary(monkeypatch, tmp_path):
+    glossary = tmp_path / "local_glossary"
+    glossary.write_text("Cloud\nCloud Native\nAI\n", encoding="utf-8")
+
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            # placeholders are expected to survive untouched
+            return {"response": "⟪GLS_0000⟫ と ⟪GLS_0001⟫ を扱う。RAIL は対象外。"}
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b", glossary_path=glossary)
+    out = tr.translate_en_to_ja("Cloud Native and AI are used. RAIL remains.")
+    assert "Cloud Native" in out
+    assert "AI" in out
+    assert "RAIL" in out
+
+
+def test_glossary_missing_placeholder_detection(monkeypatch, tmp_path):
+    glossary = tmp_path / "local_glossary"
+    glossary.write_text("Cloud Native\n", encoding="utf-8")
+
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            # token disappeared in translation output
+            return {"response": "クラウドネイティブ"}
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b", glossary_path=glossary)
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        tr.translate_en_to_ja("Cloud Native platform")
+
+
+def test_glossary_is_deterministic(monkeypatch, tmp_path):
+    glossary = tmp_path / "local_glossary"
+    glossary.write_text("Kubernetes\n", encoding="utf-8")
+
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": "⟪GLS_0000⟫ を維持"}
+
+    import ppt_local_translator.ollama_client as oc
+
+    monkeypatch.setattr(oc.requests, "post", lambda *args, **kwargs: DummyResp())
+    tr = OllamaTranslator("translategemma:4b", glossary_path=glossary)
+    src = "Kubernetes overview"
+    out1 = tr.translate_en_to_ja(src)
+    out2 = tr.translate_en_to_ja(src)
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- Add glossary masking/unmasking flow before/after translation
- Keep configured glossary terms in English by replacing them with deterministic placeholders during LLM translation
- Enforce longest-match and word-boundary matching to reduce false positives
- Detect missing placeholders after translation and fail fast
- Add non-committed local glossary support (`config/local_glossary`) and committed sample (`config/glossary.sample`)

## Details
- `ppt_local_translator/ollama_client.py`
  - Load glossary terms from `config/local_glossary`
  - Deterministic ordering (dedupe + longest-first)
  - Placeholder format: `⟪GLS_0000⟫` style
  - Restore placeholders back to original English terms after translation
  - Raise error when any glossary placeholder disappears in translated output
- `tests/test_ollama_client.py`
  - Added tests for longest-match + boundary behavior
  - Added missing-placeholder detection test
  - Added deterministic output test
- `README.md`
  - Document glossary usage and local non-commit policy
- `.gitignore`
  - Ignore `config/local_glossary`
- `config/glossary.sample`
  - Initial sample glossary terms

## Validation
- `pytest -q` passed: 16 passed
